### PR TITLE
Remove dnf and pip from finall image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN dnf -yq update &&\
       siege \
       wget \
       vim \
-      vim-powerline
+      vim-powerline && \
+      dnf clean all
 
-RUN pip install powerline-gitstatus
+RUN pip install powerline-gitstatus && rm -rf ~/.cache/pip
 
 COPY setup /


### PR DESCRIPTION
Please consider to just be sure that the final image do not have packaging metadata, this will help to get a smaller docker image.


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file;

(b) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

Signed-off-by: William Moreno Reyes williamjmorenor@gmail.com