### PR TITLE
Add mock package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf -yq update &&\
       git \
       make \
       mc \
+      mock \
       powerline \
       powerline-fonts \
       tmux \


### PR DESCRIPTION
People testing theirs development in Fedora maybe will try to ship theirs project as a .rpm

With mock you can build a rpm from sources, this is way the Fedora Project builds all rpms.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file;

(b) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

Signed-off-by: William Moreno Reyes williamjmorenor@gmail.com